### PR TITLE
Added merge, merge! and dup methods

### DIFF
--- a/test/simple_config_test.rb
+++ b/test/simple_config_test.rb
@@ -148,6 +148,40 @@ class SimpleConfigConfigTest < Test::Unit::TestCase
     assert_equal hash, @config.test_group.to_hash
   end
 
+  def test_dup_creates_deep_clone
+    new_config = cascaded_test_config.dup
+    new_config.configure do
+      group :test_group do
+        set :inner_key, 'new_foo'
+      end
+      set :test, 'new_test'
+    end
+
+    assert_equal 'test-setting', cascaded_test_config.test
+    assert_equal 'some other value', cascaded_test_config.test_group.inner_key
+    assert_equal 'new_test', new_config.test
+    assert_equal 'new_foo', new_config.test_group.inner_key
+  end
+
+  def test_config_merge_hash
+    config = SimpleConfig::Config.new
+    config.merge!(:example => {:foo => 'bar', :baz => 'qux'}, :test => 'foo')
+
+    assert_equal 'foo', config.test
+    assert_equal 'bar', config.example.foo
+    assert_equal 'qux', config.example.baz
+  end
+
+  def test_config_merge_hash_non_destructive
+    new_config = cascaded_test_config.merge(:test_group => {:inner_key => 'bar'}, :test => 'qux')
+
+    assert_equal 'test-setting', cascaded_test_config.test
+    assert_equal 'some other value', cascaded_test_config.test_group.inner_key
+    
+    assert_equal 'qux', new_config.test
+    assert_equal 'bar', new_config.test_group.inner_key
+  end
+
   private
   def cascaded_test_config
     SimpleConfig.for :simple_config_test do


### PR DESCRIPTION
Added few methods for dealing mainly with merging configurations from hash:
# merge! - merges configuration from hash by modifying original object
# dup - creates deep clone of current config object.
# merge - merges configuration from hash by creating clone of original object.
